### PR TITLE
Add Chicken 5 support

### DIFF
--- a/gl-math.egg
+++ b/gl-math.egg
@@ -1,0 +1,10 @@
+((synopsis "A small gamedev-oriented math library")
+ (author "Alex Charlton")
+ (category math)
+ (license "BSD")
+ (dependencies matchable)
+ (components (extension gl-math
+                         (csc-options "-d0" "-O3" "-C" "-O3" "-Ihypermath/include/" "-J" "-s" "hypermath/src/hypermath.c")
+                         (source "gl-math.scm")
+             )
+))

--- a/gl-math.scm
+++ b/gl-math.scm
@@ -1,12 +1,13 @@
 (module gl-math *
 
+(import scheme)
 (cond-expand
  (chicken-4
-  (import chicken scheme foreign srfi-1 extras)
+  (import chicken foreign srfi-1 extras)
   (import-for-syntax matchable data-structures)
   (use lolevel srfi-4))
  (chicken-5
-  (import (chicken base) scheme (chicken foreign) (srfi 1) (chicken format) (chicken locative))
+  (import (chicken base) (chicken foreign) (srfi 1) (chicken format) (chicken locative))
   (import-for-syntax matchable (srfi 1))
   (import (chicken memory) (srfi 4))))
 

--- a/gl-math.scm
+++ b/gl-math.scm
@@ -1,8 +1,14 @@
 (module gl-math *
 
-(import chicken scheme foreign srfi-1 extras)
-(import-for-syntax matchable data-structures)
-(use lolevel srfi-4)
+(cond-expand
+ (chicken-4
+  (import chicken scheme foreign srfi-1 extras)
+  (import-for-syntax matchable data-structures)
+  (use lolevel srfi-4))
+ (chicken-5
+  (import (chicken base) scheme (chicken foreign) (srfi 1) (chicken format) (chicken locative))
+  (import-for-syntax matchable (srfi 1))
+  (import (chicken memory) (srfi 4))))
 
 (foreign-declare "#include <hypermath.h>")
 


### PR DESCRIPTION
Added support for installing in Chicken 5 by providing an egg specification file, gl-math.egg. Chicken 5 doesn't have `(use)` anymore, so I put the import/import-for-syntax/use lines in a `cond-expand` that does the right thing on both 4 and 5.

gl-math.egg, line 7: Not confident that my `csc-options` are completely correct, but they work

I've tested this on Windows 7 mingw-msys and on macOS Mojave, though not extensively, just ran the example code.

Thanks for making this egg, hope this patch is useful!